### PR TITLE
Add ability for configurable run lengths

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 rm -rf Procfile
-python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" > Procfile
+python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" > Procfile
 
 exec "$@"

--- a/generate_procfile.py
+++ b/generate_procfile.py
@@ -1,7 +1,7 @@
 import sys
 
 
-def create_procfile(service_env_string, rpm_env_string='', *args):
+def create_procfile(service_env_string, rpm_env_string='',rls_env_string='', *args):
     services = service_env_string.split(',')
     if rpm_env_string:
         rpms = {
@@ -9,18 +9,27 @@ def create_procfile(service_env_string, rpm_env_string='', *args):
         }
     else:
         rpms = {}
+
+    if rls_env_string:
+        rls = {
+            service_name: int(rl) for service_name, rl in (entry.split(':') for entry in rls_env_string.split(','))
+        }
+    else:
+        rls = {}
+
     for service in services:
         service_name, service_url = service.split(':', maxsplit=1)
         process_name = service_name.split('-', maxsplit=1)[1].replace(
             '-', ''
         )  # we use second part of name and strip all remaining dashes
         delay = 60.0 / rpms.get(service_name, 100)
+        run_length = rls.get(service_name, 365 * 24 * 60 * 60)
         sys.stdout.write(
             '{0}: OPBEANS_BASE_URL={1} OPBEANS_NAME={2} molotov -v --duration {3} --delay {4:.3f} --uvloop molotov_scenarios.py\n'.format(
                 process_name,
                 service_url,
                 service_name,
-                365 * 24 * 60 * 60,
+                run_length,
                 delay,
             )
         )
@@ -29,4 +38,3 @@ def create_procfile(service_env_string, rpm_env_string='', *args):
 
 if __name__ == '__main__':
     create_procfile(*sys.argv[1:])
-


### PR DESCRIPTION
Currently the run length is hardcoded. This adds OPBEANS_RLS so this can be specified. Useful as sometimes we just want to run some load to generate an ML anomaly. Easier to spin up another container that terminates after the runtime.