### PR TITLE
Add Support for an IP Header + configurable number of workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+test.py
+.venv
+__pycache__/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 rm -rf Procfile
-python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" "$NUM_WOKERS" "$REAL_IP_HEADER" "$NUM_OF_IPS" > Procfile
+python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" "$NUM_WOKERS" "$NUM_OF_IPS" "$REAL_IP_HEADER"  > Procfile
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 rm -rf Procfile
-python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" "$NUM_WOKERS" "$NUM_OF_IPS" "$REAL_IP_HEADER"  > Procfile
+python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" "$NUM_OF_WORKERS" "$NUM_OF_IPS" "$REAL_IP_HEADER"  > Procfile
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 rm -rf Procfile
-python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" > Procfile
+python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" "$NUM_WOKERS" "$REAL_IP_HEADER" "$NUM_OF_IPS" > Procfile
 
 exec "$@"

--- a/generate_procfile.py
+++ b/generate_procfile.py
@@ -1,7 +1,7 @@
 import sys
 
 
-def create_procfile(service_env_string, rpm_env_string='',rls_env_string='', *args):
+def create_procfile(service_env_string, rpm_env_string='',rls_env_string='', num_workers="", num_of_ips="", ip_header="HTTP_X_FORWARDED_FOR", *args):
     services = service_env_string.split(',')
     if rpm_env_string:
         rpms = {
@@ -25,12 +25,15 @@ def create_procfile(service_env_string, rpm_env_string='',rls_env_string='', *ar
         delay = 60.0 / rpms.get(service_name, 100)
         run_length = rls.get(service_name, 365 * 24 * 60 * 60)
         sys.stdout.write(
-            '{0}: OPBEANS_BASE_URL={1} OPBEANS_NAME={2} molotov -v --duration {3} --delay {4:.3f} --uvloop molotov_scenarios.py\n'.format(
+            '{0}: OPBEANS_BASE_URL={1} OPBEANS_NAME={2} NUM_OF_IPS={6} REAL_IP_HEADER={7} molotov -v --duration {3} --delay {4:.3f} --workers {5} --uvloop molotov_scenarios.py\n'.format(
                 process_name,
                 service_url,
                 service_name,
                 run_length,
                 delay,
+                1 if num_workers == "" else int(num_workers),
+                100 if num_of_ips == "" else int(num_of_ips),
+                "HTTP_X_FORWARDED_FOR" if ip_header == "" else ip_header,
             )
         )
     sys.stdout.flush()

--- a/molotov_scenarios.py
+++ b/molotov_scenarios.py
@@ -11,7 +11,7 @@ from molotov import scenario, setup_session, global_setup
 SERVER_URL = os.environ.get('OPBEANS_BASE_URL', 'http://localhost:8000')
 SERVICE_NAME = os.environ.get('OPBEANS_NAME', 'default')
 REAL_IP_HEADER = os.environ.get('REAL_IP_HEADER','HTTP_X_FORWARDED_FOR')
-NUMBER_OF_IPS = int(os.environ.get('NUMBER_OF_IPS','100'))
+NUMBER_OF_IPS = int(os.environ.get('NUM_OF_IPS','100'))
 RANDOM_IPS=set()
 
 @global_setup()

--- a/molotov_scenarios.py
+++ b/molotov_scenarios.py
@@ -3,12 +3,27 @@ import os
 import random
 import json
 from urllib.parse import urljoin
+from faker import Faker
 
 from aiohttp import FormData
-from molotov import scenario
+from molotov import scenario, setup_session, global_setup
 
 SERVER_URL = os.environ.get('OPBEANS_BASE_URL', 'http://localhost:8000')
 SERVICE_NAME = os.environ.get('OPBEANS_NAME', 'default')
+REAL_IP_HEADER = os.environ.get('REAL_IP_HEADER','HTTP_X_FORWARDED_FOR')
+NUMBER_OF_IPS = int(os.environ.get('NUMBER_OF_IPS','100'))
+RANDOM_IPS=set()
+
+@global_setup()
+def init_test(args):
+    fake = Faker()
+    while len(RANDOM_IPS) < NUMBER_OF_IPS:
+        print(len(RANDOM_IPS))
+        RANDOM_IPS.add(fake.ipv4_public(network=False, address_class=None))
+
+@setup_session()
+async def init_session(worker_num, session):
+    session._default_headers = {REAL_IP_HEADER: random.choice(RANDOM_IPS)}
 
 
 @scenario(weight=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 honcho==1.0.1
 molotov==1.6
 uvloop==0.11.0
-
 aiohttp==3.3.2
 aiomeasures==0.5.14
 async-timeout==3.0.0
@@ -10,3 +9,7 @@ chardet==3.0.4
 idna==2.7
 multidict==4.3.1
 yarl==1.2.6
+Faker==0.9.1
+python-dateutil==2.7.3
+six==1.11.0
+text-unidecode==1.2


### PR DESCRIPTION
Adds two main features:

1. Ability to specify the number of workers through the env var `NUM_OF_WORKERS` - defaulting to 1, so not a breaking change
2. Ability to send a an IP header - the field `HTTP_X_FORWARDED_FOR` is the default. This uses a random ip value per session using faker.   The pool of ips is generated on startup. The number is configurable through NUM_OF_IPS