### PR TITLE
lighter docker image for the obpeans-loadgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM python:3.7
+FROM python:3.7-slim
+
+## Required as the slim version is too tiny
+RUN apt-get -qq update \
+ && apt-get -qq install -y \
+	gcc \
+    libc-dev \
+    bzip2 \
+    curl \
+	--no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY requirements.txt /app/
@@ -9,4 +19,4 @@ COPY molotov_scenarios.py entrypoint.sh generate_procfile.py /app/
 ENV PYTHONUNBUFFERED=1
 
 CMD ["honcho", "start"]
-ENTRYPOINT ["/bin/bash", "/app/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,24 @@
-FROM python:3.7-slim
+FROM python:3.7
 
+WORKDIR /app
+RUN python -m venv /app/venv
+COPY requirements.txt /app/
+RUN /app/venv/bin/pip install -r requirements.txt
+
+COPY molotov_scenarios.py entrypoint.sh generate_procfile.py /app/
+
+FROM python:3.7-slim
 ## Required as the slim version is too tiny
 RUN apt-get -qq update \
  && apt-get -qq install -y \
-	gcc \
-    libc-dev \
     bzip2 \
     curl \
 	--no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-COPY requirements.txt /app/
-RUN pip install -r requirements.txt
-
-COPY molotov_scenarios.py entrypoint.sh generate_procfile.py /app/
-
+COPY --from=0 /app /app
+ENV PATH="/app/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
-
+WORKDIR /app
 CMD ["honcho", "start"]
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       apm-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-java:8000/"]
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-java:8000/"]
       interval: 10s
       retries: 10
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,22 +10,122 @@ services:
           max-size: '2m'
           max-file: '5'
     links:
-       - opbeans-dotnet
+       - opbeans-java
     environment:
-      - OPBEANS_URLS=opbeans-dotnet:http://opbeans-dotnet:80
+      - OPBEANS_URLS=opbeans-java:http://opbeans-java:8000
     depends_on:
-      opbeans-dotnet:
+      opbeans-java:
         condition: service_healthy
 
-  opbeans-dotnet:
-    image: opbeans/opbeans-dotnet:latest
-    container_name: opbeans-dotnet
+  opbeans-java:
+    image: opbeans/opbeans-java:latest
+    container_name: opbeans-java
+    logging:
+      driver: 'json-file'
+      options:
+          max-size: '2m'
+          max-file: '5'
+    environment:
+      - ELASTIC_APM_SERVICE_NAME=${ELASTIC_APM_SERVICE_NAME:-opbeans-java}
+      - ELASTIC_APM_SERVER_URL=${ELASTIC_APM_SERVER_URL:-http://apm-server:8200}
+      - ELASTIC_APM_APPLICATION_PACKAGES=co.elastic.apm.opbeans
+      - ELASTIC_APM_JS_SERVER_URL=${ELASTIC_APM_JS_SERVER_URL:-http://localhost:8200}
+      - OPBEANS_SERVER_PORT=${OPBEANS_SERVER_PORT:-8000}
+    depends_on:
+      apm-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--server-response", "-O", "/dev/null", "http://opbeans-java:8000/"]
+      interval: 10s
+      retries: 10
+
+  apm-server:
+    image: docker.elastic.co/apm/apm-server:${STACK_VERSION:-7.3.0}
+    ports:
+      - "127.0.0.1:${APM_SERVER_PORT:-8200}:8200"
+      - "127.0.0.1:${APM_SERVER_MONITOR_PORT:-6060}:6060"
+    command: >
+      apm-server -e
+        -E apm-server.frontend.enabled=true
+        -E apm-server.frontend.rate_limit=100000
+        -E apm-server.host=0.0.0.0:8200
+        -E apm-server.read_timeout=1m
+        -E apm-server.shutdown_timeout=2m
+        -E apm-server.write_timeout=1m
+        -E apm-server.rum.enabled=true
+        -E setup.kibana.host=kibana:5601
+        -E setup.template.settings.index.number_of_replicas=0
+        -E xpack.monitoring.elasticsearch=true
+        -E output.elasticsearch.enabled=${APM_SERVER_ELASTICSEARCH_OUTPUT_ENABLED:-true}
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
+    logging:
+      driver: 'json-file'
+      options:
+          max-size: '2m'
+          max-file: '5'
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://apm-server:8200/"]
+      retries: 10
+      interval: 10s
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.3.0}
+    environment:
+      - cluster.name=docker-cluster
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - network.host=0.0.0.0
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "path.data=/usr/share/elasticsearch/data/${STACK_VERSION:-7.3.0}"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 2g
+    logging:
+      driver: 'json-file'
+      options:
+          max-size: '2m'
+          max-file: '5'
+    ports:
+      - "127.0.0.1:${ELASTICSEARCH_PORT:-9200}:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -vq '\"status\":\"red\"'"]
+      retries: 10
+      interval: 20s
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION:-7.3.0}
+    environment:
+      SERVER_NAME: kibana.example.org
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+    ports:
+      - "127.0.0.1:${KIBANA_PORT:-5601}:5601"
     logging:
       driver: 'json-file'
       options:
           max-size: '2m'
           max-file: '5'
     healthcheck:
-      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://opbeans-dotnet:80/"]
-      interval: 10s
+      test: ["CMD", "curl", "--write-out", "'HTTP %{http_code}'", "--silent", "--output", "/dev/null", "http://kibana:5601/"]
       retries: 10
+      interval: 10s
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+
+volumes:
+  esdata:
+    driver: local

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 rm -rf Procfile
 python3 generate_procfile.py "$OPBEANS_URLS" "$OPBEANS_RPMS" "$OPBEANS_RLS" > Procfile


### PR DESCRIPTION
## Highlights

- Docker image size reduced from `950mb` to `220MB`.
- Depends on the java one: https://github.com/elastic/opbeans-java/pull/38
