### PR TITLE
Latency distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 .idea
 *.swp
 Procfile

--- a/dyno/app/api/control.py
+++ b/dyno/app/api/control.py
@@ -417,7 +417,7 @@ def _construct_toxi_env(
         specifies the lower bound for latency. Requests will never be
         less latent than this value.
 
-    app_latency_upper_bound : str
+    app_latency_upper_bound : int
         Used in conjunction with `app_latency_weight`, this parameter
         specifies the upper bound for latency. Requests will never by (much)
         more latent than this value.

--- a/dyno/app/api/control.py
+++ b/dyno/app/api/control.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 import subprocess
 import signal
 
@@ -8,12 +7,13 @@ from pathlib import Path
 
 from . import bp
 import socketio
-from flask import request, abort
+from flask import request
 
 # TODO Pull this from config object instead
 DEBUG = os.environ.get('DYNO_DEBUG')
 
 """ Public HTTP methods """
+
 
 @bp.route('/start', methods=['POST'])
 def start_job() -> dict:
@@ -53,19 +53,25 @@ def start_job() -> dict:
         https://molotov.readthedocs.io/en/stable/cli/?highlight=workers#command-line-options
 
     error_weight : str
-        The relative "weight" of errors. Higher number result in the load generator
-        choosing to hit pages known to produce errors a higher percentage of the time.
-        This number is entirely arbitrary and is only relative to statically configured
-        weights in the scenario file itself.
+        The relative "weight" of errors. Higher number result in the load
+        generator choosing to hit pages known to produce errors a higher
+        percentage of the time.
+
+        This number is entirely arbitrary and is only relative to statically
+        configured weights in the scenario file itself.
 
     label_weight : str
-        In the case of the `dyno` scenario, a label_weight parameter can be passed which
-        increases the rate at which a given label is accessed. The label weight is controlled
-        via the `label_name` parameter. Does NOT work with scenarios other than `dyno`!
+        In the case of the `dyno` scenario, a label_weight parameter can be
+        passed which increases the rate at which a given label is accessed.
+
+        The label weight is controlled via the `label_name` parameter.
+
+        Does NOT work with scenarios other than `dyno`!
 
     label_name : str
-        Used in conjunction with `label_weight` to specify a label which should be hit at a higher
-        or lower rate, which is controlled by the `label_weight` parameters.
+        Used in conjunction with `label_weight` to specify a label which
+        should be hit at a higher or lower rate, which is controlled by the
+        `label_weight` parameters.
 
 
     Examples
@@ -132,6 +138,7 @@ def get_list() -> dict:
     """
     return JOB_STATUS
 
+
 @bp.route('/update', methods=['POST'])
 def update_job() -> dict:
     """
@@ -155,19 +162,23 @@ def update_job() -> dict:
         The number of workers the load generator should use. (Optional)
 
     error_weight : str
-        The relative "weight" of errors. Higher number result in the load generator
-        choosing to hit pages known to produce errors a higher percentage of the time.
-        This number is entirely arbitrary and is only relative to statically configured
-        weights in the scenario file itself. (Optional)
+        The relative "weight" of errors. Higher number result in the load
+        generator choosing to hit pages known to produce errors a higher
+        percentage of the time.
+
+        This number is entirely arbitrary and is only relative to statically
+        configured weights in the scenario file itself. (Optional)
 
     label_weight : str
-        In the case of the `dyno` scenario, a label_weight parameter can be passed which
-        increases the rate at which a given label is accessed. The label weight is controlled
-        via the `label_name` parameter. Does NOT work with scenarios other than `dyno`! (Optional)
+        In the case of the `dyno` scenario, a label_weight parameter can be
+        passed which increases the rate at which a given label is accessed.
+        The label weight is controlled via the `label_name` parameter.
+        Does NOT work with scenarios other than `dyno`! (Optional)
 
     label_name : str
-        Used in conjunction with `label_weight` to specify a label which should be hit at a higher
-        or lower rate, which is controlled by the `label_weight` parameters.
+        Used in conjunction with `label_weight` to specify a label which
+        should be hit at a higher or lower rate, which is controlled by
+        the `label_weight` parameters.
 
     Returns
     -------
@@ -263,21 +274,21 @@ def get_scenarios() -> dict:
 
     Note
     ----
-    To add a new scenario to the application, it must be added to the scenarios/
-    folder before it appears in this list.
-    
+    To add a new scenario to the application, it must be added to the
+    scenarios/ folder before it appears in this list.
+
     Examples
     --------
-	❯ curl -s http://localhost:8999/api/scenarios|jq
-	{
-	  "scenarios": [
-	    "dyno",
-	    "molotov_scenarios",
-	    "high_error_rates"
-	  ]
-	}
+    ❯ curl -s http://localhost:8999/api/scenarios|jq
+    {
+        "scenarios": [
+            "dyno",
+            "molotov_scenarios",
+            "high_error_rates"
+        ]
+    }
     """
-    cur_dir = os.path.dirname(os.path.realpath(__file__)) 
+    cur_dir = os.path.dirname(os.path.realpath(__file__))
     scenario_dir = os.path.join(cur_dir, "../../../scenarios")
 
     files = os.listdir(scenario_dir)
@@ -293,6 +304,7 @@ def get_scenarios() -> dict:
 
 
 """ Private helper functions """
+
 
 def _construct_toxi_env(
         job: str,
@@ -315,7 +327,8 @@ def _construct_toxi_env(
     Parameters
     ----------
     job : str
-       The name of the job. Should be passed without including the `opbeans-` prefix.
+       The name of the job. Should be passed without including the `opbeans-`
+       prefix.
 
     port : str
         The port for the environment. Can also be passed as a int type.
@@ -325,32 +338,39 @@ def _construct_toxi_env(
         the name and NOT as a filename.
 
     error_weight : int
-        The relative "weight" of errors. Higher number result in the load generator
-        choosing to hit pages known to produce errors a higher percentage of the time.
-        This number is entirely arbitrary and is only relative to statically configured
-        weights in the scenario file itself.
+        The relative "weight" of errors. Higher number result in the load
+        generator choosing to hit pages known to produce errors a higher
+        percentage of the time.
+
+        This number is entirely arbitrary and is only relative to statically
+        configured weights in the scenario file itself.
 
     label_weight : int
-        In the case of the `dyno` scenario, a label_weight parameter can be passed which
-        increases the rate at which a given label is accessed. The label weight is controlled
-        via the `label_name` parameter. Does NOT work with scenarios other than `dyno`!
+        In the case of the `dyno` scenario, a label_weight parameter can be
+        passed which increases the rate at which a given label is accessed.
+        The label weight is controlled via the `label_name` parameter. Does
+        NOT work with scenarios other than `dyno`!
 
     label_name : str
-        Used in conjunction with `label_weight` to specify a label which should be hit at a higher
-        or lower rate, which is controlled by the `label_weight` parameters.
+        Used in conjunction with `label_weight` to specify a label which
+        should be hit at a higher or lower rate, which is controlled by the
+        `label_weight` parameters.
 
-    
     Returns
     -------
     dict
         Dictionary containing the environment keys and values
-   
+
     Examples
     --------
     Sample call showing just the required parameters
 
     >>> _construct_toxi_env('python', 9999, 'my_great-scenario', 99)
-    {'OPBEANS_BASE_URL': 'http://toxi:9999', 'OPBEANS_NAME': 'opbeans-python', 'ERROR_WEIGHT': '99'}
+    {
+        'OPBEANS_BASE_URL': 'http://toxi:9999',
+        'OPBEANS_NAME': 'opbeans-python',
+        'ERROR_WEIGHT': '99'
+    }
 
     """
     toxi_env = os.environ.copy()
@@ -446,13 +466,15 @@ def _launch_job(job: str, config: dict) -> None:
     >>> update_status('python', config)
     """
     if DEBUG:
-        print('Job launch received: ',
-                config['job'], config['port'],
-                config['duration'],
-                config['delay'],
-                config['workers'],
-                config['scenario'],
-                config['error_weight'])
+        print(
+            'Job launch received: ',
+            config['job'], config['port'],
+            config['duration'],
+            config['delay'],
+            config['workers'],
+            config['scenario'],
+            config['error_weight']
+        )
 
     if DEBUG:
         cmd = ['sleep', '10']
@@ -485,13 +507,14 @@ def _launch_job(job: str, config: dict) -> None:
             config['error_weight']
             )
 
-    _update_status(job, config) 
+    _update_status(job, config)
 
     # “I may not have gone where I intended to go, but I think I have ended up
     # where I needed to be.”
     # ― Douglas Adams, The Long Dark Tea-Time of the Soul
     p = subprocess.Popen(cmd, cwd="../", preexec_fn=os.setsid, env=toxi_env)
     JOB_MANAGER[job] = p
+
 
 def _stop_job(job: str) -> None:
     """

--- a/dyno/app/api/control.py
+++ b/dyno/app/api/control.py
@@ -60,19 +60,24 @@ def start_job() -> dict:
         This number is entirely arbitrary and is only relative to statically
         configured weights in the scenario file itself.
 
-    label_weight : str
-        In the case of the `dyno` scenario, a label_weight parameter can be
-        passed which increases the rate at which a given label is accessed.
-
-        The label weight is controlled via the `label_name` parameter.
+    app_latency_weight : str
+        In the case of the `dyno` scenario, an app_latency_weight
+        parameter can be passed which increases the rate at which a given
+        label is accessed.
 
         Does NOT work with scenarios other than `dyno`!
 
-    label_name : str
-        Used in conjunction with `label_weight` to specify a label which
-        should be hit at a higher or lower rate, which is controlled by the
-        `label_weight` parameters.
+    app_latency_label : str
+        Used in conjunction with `app_latency_weightr` to specify a
+        label which should be hit at a higher or lower rate.
 
+    app_latency_lower_bound : int
+        The lower bound of latency which should be applied to requests which
+        hit the delayed endpoint
+
+    app_latency_upper_bound : int
+        The upper bound of latency which should be applied to requests which
+        hit the delayed endpoint
 
     Examples
     --------
@@ -88,8 +93,10 @@ def start_job() -> dict:
             'delay': r.get('delay', "0.600"),
             'workers': r.get('workers', "3"),
             'error_weight': r.get('error_weight', "0"),
-            'label_weight': r.get('label_weight', "2"),
-            'label_name': r.get('label_name', 'foo_label')
+            'app_latency_weight': r.get('app_latency_weight', "0"),
+            'app_latency_label': r.get('app_latency_label', 'dyno_latency'), # noqa
+            'app_latency_lower_bound': r.get('app_latency_lower_bound', 1),  # noqa
+            'app_latency_upper_bound': r.get('app_latency_upper_bound', 1000),  # noqa
             }
 
     job = job.replace('opbeans-', '')
@@ -126,8 +133,10 @@ def get_list() -> dict:
         "delay": "0.600",
         "duration": "31536000",
         "error_weight": "0",
-        "label_name": "foo_label",
-        "label_weight": "2",
+        "app_latency_label": "dyno_delay",
+        "app_latency_weight": "2",
+        "app_latency_lower_bound": "1",
+        "app_latency_upper_bound": "1000",
         "name": "python",
         "port": "8000",
         "running": false,
@@ -169,16 +178,25 @@ def update_job() -> dict:
         This number is entirely arbitrary and is only relative to statically
         configured weights in the scenario file itself. (Optional)
 
-    label_weight : str
-        In the case of the `dyno` scenario, a label_weight parameter can be
-        passed which increases the rate at which a given label is accessed.
-        The label weight is controlled via the `label_name` parameter.
+    app_latency_weight : str
+        In the case of the `dyno` scenario, an `app_latency_weight`
+        parameter can be passed which increases the rate at which a given
+        label is accessed.
+
         Does NOT work with scenarios other than `dyno`! (Optional)
 
-    label_name : str
-        Used in conjunction with `label_weight` to specify a label which
+    app_latency_label : str
+        Used in conjunction with `app_latency_eight` to specify a label which
         should be hit at a higher or lower rate, which is controlled by
-        the `label_weight` parameters.
+        the `app_latency_weight` parameter.
+
+    app_latency_lower_bound : int
+        The lower bound of latency which should be applied to requests which
+        hit the delayed endpoint
+
+    app_latency_upper_bound : int
+        The upper bound of latency which should be applied to requests which
+        hit the delayed endpoint
 
     Returns
     -------
@@ -206,7 +224,11 @@ def update_job() -> dict:
                 'delay': "0.600",
                 "scenario": "molotov_scenarios",
                 "workers": r.get('workers', "3"),
-                "error_weight": r.get('error_weight', "0")
+                "error_weight": r.get('error_weight', "0"),
+                "app_latency_weight": r.get('app_latency_weight', 0),
+                "app_latency_label": r.get("app_latency_label", "dyno_app_latency"),  # noqa
+                "app_latency_lower_bound": r.get("app_latency_lower_bound", 1),
+                "app_latency_upper_bound": r.get("app_latency_upper_bound", 1000)  # noqa
                 }
         return {}
 
@@ -216,10 +238,14 @@ def update_job() -> dict:
         config['workers'] = r['workers']
     if 'error_weight' in r:
         config['error_weight'] = r['error_weight']
-    if 'label_weight' in r:
-        config['label_weight'] = r['label_weight']
-    if 'label_name' in r:
-        config['label_name'] = r['label_name']
+    if 'app_latency_weight' in r:
+        config['app_latency_weight'] = r['app_latency_weight']
+    if 'app_latency_label' in r:
+        config['app_latency_label'] = r['app_latency_label']
+    if 'app_latency_lower_bound' in r:
+        config['app_latency_lower_bound'] = r['app_latency_lower_bound']
+    if 'app_latency_upper_bound' in r:
+        config['app_latency_upper_bound'] = r['app_latency_upper_bound']
     _stop_job(job)
 
     if DEBUG:
@@ -256,6 +282,35 @@ def stop_job() -> dict:
     job = job.replace('opbeans-', '')
     _stop_job(job)
     return {}
+
+
+@bp.route('/splays', methods=['GET'])
+def get_splays() -> dict:
+    """
+    Fetch a list of splays
+
+    Exposed via HTTP at /api/splays
+    Supported HTTP methods: GET
+
+    Returns
+    -------
+    dict
+        A dictionary containing a list of possible splay. A splay
+        is a property across which delayed requests are distributed.
+
+    Examples
+    --------
+    ❯ curl -s http://localhost:8999/api/splays|jq
+    {
+        "splays": [
+            "User-agent: Safari",
+            "IP addresses: 10.0.0.0/8"
+        ]
+    }
+    """
+    # Fixed for the time being
+    ret = {'splays': ['User-Agent: Safari']}
+    return ret
 
 
 @bp.route('/scenarios', methods=['GET'])
@@ -311,8 +366,11 @@ def _construct_toxi_env(
         port: str,
         scenario: str,
         error_weight: int,
-        label_weight=None,
-        label_name=None
+        app_latency_weight=None,
+        app_latency_label=None,
+        app_latency_lower_bound=None,
+        app_latency_upper_bound=None,
+
         ) -> dict:
     """
     Construct a dictionary representing an Opbeans environment
@@ -345,16 +403,28 @@ def _construct_toxi_env(
         This number is entirely arbitrary and is only relative to statically
         configured weights in the scenario file itself.
 
-    label_weight : int
-        In the case of the `dyno` scenario, a label_weight parameter can be
-        passed which increases the rate at which a given label is accessed.
-        The label weight is controlled via the `label_name` parameter. Does
-        NOT work with scenarios other than `dyno`!
+    app_latency_weight : int
+        In the case of the `dyno` scenario, the app_latency_weight parameter
+        can be passed which increases the rate at which an endpoint which
+        artifically introduces latency is hit.
 
-    label_name : str
-        Used in conjunction with `label_weight` to specify a label which
-        should be hit at a higher or lower rate, which is controlled by the
-        `label_weight` parameters.
+    app_latency_label : str
+        Used in conjunction with `app_latency_weight` to specify a label which
+        should be applied to latent requests.
+
+    app_latency_lower_bound : int
+        Used in conjunction with `app_latency_weight`, this parameter
+        specifies the lower bound for latency. Requests will never be
+        less latent than this value.
+
+    app_latency_upper_bound : str
+        Used in conjunction with `app_latency_weight`, this parameter
+        specifies the upper bound for latency. Requests will never by (much)
+        more latent than this value.
+
+    app_latency_user_agent : str
+        Used in conjunction with `app_latency_weight`, this parameter
+        specifies a user agent for the latent requests.
 
     Returns
     -------
@@ -377,10 +447,14 @@ def _construct_toxi_env(
     toxi_env['OPBEANS_BASE_URL'] = "http://toxi:{}".format(port)
     toxi_env['OPBEANS_NAME'] = "opbeans-" + job
     toxi_env['ERROR_WEIGHT'] = str(error_weight)
-
-    if scenario == 'dyno':
-        toxi_env['LABEL_WEIGHT'] = str(label_weight)
-        toxi_env['LABEL_NAME'] = label_name
+    if app_latency_weight:
+        toxi_env['APP_LATENCY_WEIGHT'] = str(app_latency_weight)
+    if app_latency_label:
+        toxi_env['APP_LATENCY_LABEL'] = app_latency_label
+    if app_latency_lower_bound:
+        toxi_env['APP_LATENCY_LOWER_BOUND'] = str(app_latency_lower_bound)
+    if app_latency_upper_bound:
+        toxi_env['APP_LATENCY_UPPER_BOUND'] = str(app_latency_upper_bound)
     return toxi_env
 
 
@@ -413,8 +487,9 @@ def _update_status(job: str, config: dict) -> None:
     --------
     >>> config = {'duration': '90', 'delay': '91', \
             'scenario': 'dyno', 'workers': '92',\
-            'error_weight': '93', 'port': '95',
-            'label_weight': '96','label_name': '99'}
+            'error_weight': '93', 'port': '95', \
+            'app_latency_weight': '96','app_latency_label': 'my_label', \
+            'app_latency_lower_bound': 1,'app_latency_upper_bound': 1000}
     >>> update_status('python', config)
     """
     if job not in JOB_STATUS:
@@ -424,7 +499,11 @@ def _update_status(job: str, config: dict) -> None:
                 'delay': "0.600",
                 "scenario": "molotov_scenarios",
                 "workers": "3",
-                "error_weight": "0"
+                "error_weight": "0",
+                "app_latency_weight": "0",
+                "app_latency_label": "dyno_app_latency",
+                "app_latency_lower_bound": "1",
+                "app_latency_upper_bound": "1000"
                 }
     status = JOB_STATUS[job]
     status['running'] = True
@@ -434,8 +513,10 @@ def _update_status(job: str, config: dict) -> None:
     status['workers'] = config['workers']
     status['error_weight'] = config['error_weight']
     status['port'] = config['port']
-    status['label_weight'] = config.get('label_weight')
-    status['label_name'] = config.get('label_name')
+    status['app_latency_weight'] = config.get('app_latency_weight')
+    status['app_latency_label'] = config.get('app_latency_label')
+    status['app_latency_lower_bound'] = config.get('app_latency_lower_bound')
+    status['app_latency_upper_bound'] = config.get('app_latency_upper_bound')
     status['name'] = job
 
 
@@ -467,13 +548,7 @@ def _launch_job(job: str, config: dict) -> None:
     """
     if DEBUG:
         print(
-            'Job launch received: ',
-            config['job'], config['port'],
-            config['duration'],
-            config['delay'],
-            config['workers'],
-            config['scenario'],
-            config['error_weight']
+            'Job launch received: ', config
         )
 
     if DEBUG:
@@ -504,7 +579,14 @@ def _launch_job(job: str, config: dict) -> None:
             job,
             config['port'],
             config['scenario'],
-            config['error_weight']
+            config['error_weight'],
+            # TODO These are optional so that we don't
+            # break backward compatability with older clients.
+            # Eventually the lookup fallbacks can be removed.
+            config.get('app_latency_weight'),
+            config.get('app_latency_label'),
+            config.get('app_latency_lower_bound'),
+            config.get('app_latency_upper_bound'),
             )
 
     _update_status(job, config)

--- a/dyno/app/api/control.py
+++ b/dyno/app/api/control.py
@@ -16,7 +16,7 @@ DEBUG = os.environ.get('DYNO_DEBUG')
 """ Public HTTP methods """
 
 @bp.route('/start', methods=['POST'])
-def start_job():
+def start_job() -> dict:
     """
     Start a load-generation job
 
@@ -97,7 +97,7 @@ def start_job():
 
 
 @bp.route('/list', methods=['GET'])
-def get_list():
+def get_list() -> dict:
     """
     Return the current status of all configured
     jobs
@@ -133,7 +133,7 @@ def get_list():
     return JOB_STATUS
 
 @bp.route('/update', methods=['POST'])
-def update_job():
+def update_job() -> dict:
     """
     Updates a job with a new configuration.
 
@@ -219,7 +219,7 @@ def update_job():
 
 
 @bp.route('/stop', methods=['GET'])
-def stop_job():
+def stop_job() -> dict:
     """
     Stop a load-generation job
 
@@ -248,7 +248,7 @@ def stop_job():
 
 
 @bp.route('/scenarios', methods=['GET'])
-def get_scenarios():
+def get_scenarios() -> dict:
     """
     Fetch a list of scenarios.
 
@@ -295,13 +295,13 @@ def get_scenarios():
 """ Private helper functions """
 
 def _construct_toxi_env(
-        job,
-        port,
-        scenario,
-        error_weight,
+        job: str,
+        port: str,
+        scenario: str,
+        error_weight: int,
         label_weight=None,
         label_name=None
-        ):
+        ) -> dict:
     """
     Construct a dictionary representing an Opbeans environment
     which is fronted by a Toxiproxy instance.
@@ -364,7 +364,7 @@ def _construct_toxi_env(
     return toxi_env
 
 
-def _update_status(job, config):
+def _update_status(job: str, config: dict) -> None:
     """
     Helper function for updating the status of a job
 
@@ -419,7 +419,7 @@ def _update_status(job, config):
     status['name'] = job
 
 
-def _launch_job(job, config):
+def _launch_job(job: str, config: dict) -> None:
     """
     Spawn a new load-generation job
 
@@ -493,7 +493,7 @@ def _launch_job(job, config):
     p = subprocess.Popen(cmd, cwd="../", preexec_fn=os.setsid, env=toxi_env)
     JOB_MANAGER[job] = p
 
-def _stop_job(job):
+def _stop_job(job: str) -> None:
     """
     Helper function for stopping a job
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 pytest==6.2.1
 pytest-flask==1.1.0
 requests==2.25.1
-
+flake8==3.8.4

--- a/scenarios/molotov_scenarios.py
+++ b/scenarios/molotov_scenarios.py
@@ -2,7 +2,6 @@ import io
 import os
 import random
 import json
-import pprint
 from urllib.parse import urljoin
 
 from aiohttp import FormData
@@ -117,7 +116,6 @@ async def scenario_orders_post(session):
 if SERVICE_NAME.startswith('opbeans-python'):
     @scenario(weight=APP_LATENCY_WEIGHT)
     async def scenario_brower_latency_distribution(session):
-        pprint.pprint(os.environ)
         async with session.get(
             join(
                 SERVER_URL,

--- a/scenarios/molotov_scenarios.py
+++ b/scenarios/molotov_scenarios.py
@@ -2,6 +2,7 @@ import io
 import os
 import random
 import json
+import pprint
 from urllib.parse import urljoin
 
 from aiohttp import FormData
@@ -10,6 +11,7 @@ from molotov import scenario
 SERVER_URL = os.environ.get('OPBEANS_BASE_URL', 'http://localhost:8000')
 SERVICE_NAME = os.environ.get('OPBEANS_NAME', 'default')
 ERROR_WEIGHT = int(os.environ.get('ERROR_WEIGHT', 2))
+APP_LATENCY_WEIGHT = int(float(os.environ.get('APP_LATENCY_WEIGHT', 0)))
 
 print("SERVICE NAME", SERVICE_NAME)
 print("ERROR WEIGHT", ERROR_WEIGHT)
@@ -111,6 +113,31 @@ async def scenario_orders_post(session):
     async with session.post(join(SERVER_URL, 'api', 'orders'), data=json.dumps(data)) as resp:
         assert resp.status == 200, resp.status
 
+
+if SERVICE_NAME.startswith('opbeans-python'):
+    @scenario(weight=APP_LATENCY_WEIGHT)
+    async def scenario_brower_latency_distribution(session):
+        pprint.pprint(os.environ)
+        async with session.get(
+            join(
+                SERVER_URL,
+                'labeldelay' +
+                '?delay=' +
+                str(random.randint(
+                    int(float(os.environ.get('APP_LATENCY_LOWER_BOUND', 1))),
+                    int(float(os.environ.get('APP_LATENCY_UPPER_BOUND', 1000)))
+                )) +
+                '&label=' +
+                os.environ.get('APP_LATENCY_LABEL', 'browser_latency_delay')
+            ),
+            headers={
+                'User-Agent': os.environ.get(
+                    'APP_LATENCY_USER_AGENT',
+                    'Safari/531.21.10'
+                    )
+                }
+        ) as resp:
+            assert resp.status == 200, resp.status
 
 if SERVICE_NAME.startswith(tuple(['opbeans-python', 'opbeans-go'])):
     @scenario(weight=ERROR_WEIGHT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,15 +23,17 @@ import os
 import pytest
 import dyno.app
 
+
 @pytest.fixture
 def default_environment(monkeypatch):
     """
     Set up default variables to produce a functional
     test environment
     """
-    monkeypatch.setenv("OPBEANS_URLS", "opbeans-python:http://opbeans-python:3000")
+    monkeypatch.setenv("OPBEANS_URLS", "opbeans-python:http://opbeans-python:3000")  # noqa
     monkeypatch.setenv("OPBEANS_RPMS", "opbeans-python:500")
     monkeypatch.setenv("OPBEANS_RLS", "opbeans-python:500")
+
 
 @pytest.fixture(scope="session")
 def app():
@@ -45,6 +47,7 @@ def app():
     dyno_app = dyno.app.create_app(app_env='test')
     return dyno_app
 
+
 @pytest.fixture
 def scenarios():
     """
@@ -56,6 +59,7 @@ def scenarios():
     scenario_files = os.listdir(fixture_path)
     scenarios = [scenario.replace('.py', '') for scenario in scenario_files]
     return scenarios
+
 
 @pytest.fixture
 def procfile():
@@ -87,8 +91,10 @@ def job_status():
                 'workers': '993',
                 'scenario': 'fake_scenario',
                 'error_weight': '994',
-                'label_weight': '995',
-                'label_name': 'fake_label_name',
-                'p': None}
+                'app_latency_weight': 661,
+                'app_latency_label': 'fake_label_name',
+                'app_latency_lower_bound': 699,
+                'app_latency_upper_bound': 771,
+                'p': None
+                }
             }
-


### PR DESCRIPTION
This introduces the capability to distribute the latency for a a segment of requests over a range of delay time periods. Using this capability, the new `Correlations` feature of the APM UI can be exercised by controlling the number of requests which are delayed and tying them to an arbitrary factor. 

In the case of this PR, the common factor is `User-Agent: Safari` but in future work, this will be extended to other factors, such as source IP addresses.

## Changes

* Changes the argument formerly called `label_name` to `app_latency_label`. The previous value was not in use by the UI so this is a non-breaking change.
