### PR TITLE
fix: remove aiomeasures dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 honcho==1.0.1
-molotov==2.1
+molotov==2.4
 uvloop==0.11.0
 aiohttp==3.3.2
-aiomeasures==0.5.14
 async-timeout==3.0.0
 attrs
 chardet==3.0.4


### PR DESCRIPTION
The build failed because the package aiomeasures is not available, this package is used by Molotov. Molotov has removed this dependency in the 2.4 version so we bump the version of Molotov to resolve the issue.

```
#13 6.214 ERROR: Could not find a version that satisfies the requirement aiomeasures==0.5.14 (from -r requirements.txt (line 5)) (from versions: none)
#13 6.215 ERROR: No matching distribution found for aiomeasures==0.5.14 (from -r requirements.txt (line 5))
#13 6.228 WARNING: You are using pip version 20.1.1; however, version 22.0.3 is available.
#13 6.228 You should consider upgrading via the '/app/venv/bin/python -m pip install --upgrade pip' command.
```

https://pypi.org/project/molotov/2.4/