### PR TITLE
fix: use fixed version of itsdangerous package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ eventlet==0.29.1
 flask==1.1.2
 flask-socketio==4.3.2
 flask-cors==3.0.9
-
+itsdangerous==2.0.1


### PR DESCRIPTION
One of the Flask dependencies is not fixed and has incompatible changes in the latest versions.

https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous