### PR TITLE
pin flask 1.x deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.7
 WORKDIR /app
 RUN python -m venv /app/venv
 COPY requirements.txt /app/
+RUN /app/venv/bin/pip install wheel
 RUN /app/venv/bin/pip install -r requirements.txt
 
 COPY molotov_scenarios.py entrypoint.sh generate_procfile.py /app/

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,8 @@ flask==1.1.2
 flask-socketio==4.3.2
 flask-cors==3.0.9
 itsdangerous==2.0.1
+
+## Temporary pins for old flask
+Jinja2==2.11.3
+markupsafe==2.0.1
+werkzeug==2.0.3


### PR DESCRIPTION
## The problem

opbeans/opbeans-loadgen fails to start with:
```
...
  File "/app/dyno/app/__init__.py", line 22, in <module>
    from flask import Flask, render_template
  File "/app/venv/lib/python3.7/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (/app/venv/lib/python3.7/site-packages/jinja2/__init__.py)
[2022-07-14 16:05:13 +0000] [12] [INFO] Worker exiting (pid: 12)
[2022-07-14 16:05:13 +0000] [9] [INFO] Shutting down: Master
[2022-07-14 16:05:13 +0000] [9] [INFO] Reason: Worker failed to boot.
```

## The fix

Pinning various packages restores the existing behavior.  We should upgrade to flask 2.x (or 3.x) for a real fix, this will just get load generation running again quickly.

Flask 2.1.3 was released yesterday but I'm not sure how that would impact this.