### PR TITLE
requirements: bump uvloop to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 honcho==1.0.1
 molotov==2.4
-uvloop==0.11.0
+uvloop==0.19.0
 aiohttp==3.3.2
 async-timeout==3.0.0
 attrs


### PR DESCRIPTION
So it is installable in python 3.10