### PR TITLE
deps: pin 3.10 python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # As long as the dependencies are not updated
+    # Fixes: AttributeError: module 'asyncio.coroutines' has no attribute '_DEBUG'
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
     - name: Run build
       run: make build
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ async-timeout==3.0.0
 attrs
 chardet==3.0.4
 idna==3.7
-multidict==4.3.1
+multidict==4.5.2
 yarl==1.2.6
 
 # Dyno

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 honcho==1.0.1
 molotov==2.4
 uvloop==0.19.0
-aiohttp==3.8.1
+aiohttp==3.3.2
 async-timeout==3.0.0
 attrs
 chardet==3.0.4
 idna==3.7
-multidict==4.5.2
+multidict==4.3.1
 yarl==1.2.6
 
 # Dyno

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 honcho==1.0.1
 molotov==2.4
 uvloop==0.19.0
-aiohttp==3.3.2
+aiohttp==3.8.1
 async-timeout==3.0.0
 attrs
 chardet==3.0.4


### PR DESCRIPTION
trying to fix AttributeError: module 'asyncio.coroutines' has no attribute '_DEBUG'



```
    from . import hdrs, helpers, http, multipart, payload
venv/lib/python3.12/site-packages/aiohttp/helpers.py:62: in <module>
    old_debug = coroutines._DEBUG
E   AttributeError: module 'asyncio.coroutines' has no attribute '_DEBUG'
make: *** [Makefile:37: test] Error 4
```

When using `ubuntu-latest` -> `ubuntu-24.04` therefore the default python version is 3.12 instead of 3.9